### PR TITLE
Fix Discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <a href="mailto:rta480626@gmail.com"><img align="left" alt="Tony | Gmail" width="30px" src="https://user-images.githubusercontent.com/85498401/169121662-0519961d-91eb-4c21-acd2-677330734f6b.png"/></a>
 [<img align="left" alt="Tony | LinkedIn" width="30px" src="https://user-images.githubusercontent.com/85498401/158425770-5bf4e358-d2e8-49a0-b8a0-e9edfa6a2f16.png"/>](https://www.linkedin.com/in/triteb-rojsawangthip/)
 [<img align="left" alt="Tony | Instagram" width="30px" src="https://user-images.githubusercontent.com/85498401/155031196-9e759d41-3199-4603-87e7-048a38972ceb.png"/>](https://www.instagram.com/tony22180/)
-[<img align="left" alt="Tony | Discord" width="30px" src="https://user-images.githubusercontent.com/85498401/155056362-ca621596-aa70-4079-9b86-723a4b8fd585.png"/>](https://discord.com/users/<326811469381632004>)
+[<img align="left" alt="Tony | Discord" width="30px" src="https://user-images.githubusercontent.com/85498401/155056362-ca621596-aa70-4079-9b86-723a4b8fd585.png"/>](https://discord.com/users/326811469381632004)
 
 <!---
 Tony22180/Tony22180 is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.


### PR DESCRIPTION
Removed an extra pair of angle brackets, `<>`, that were causing the Discord link to not function.